### PR TITLE
Pull request for WAZO-2658-docker-compose-v2

### DIFF
--- a/wazo_test_helpers/asset_launching_test_case.py
+++ b/wazo_test_helpers/asset_launching_test_case.py
@@ -1,4 +1,4 @@
-# Copyright 2015-2021 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2015-2022 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import logging
@@ -117,7 +117,11 @@ class AssetLaunchingTestCase(unittest.TestCase):
 
     @classmethod
     def pull_containers(cls):
-        _run_cmd(['docker-compose'] + cls._docker_compose_options() + ['pull'])
+        _run_cmd(
+            ['docker-compose'] +
+            cls._docker_compose_options() +
+            ['pull', '--ignore-pull-failures']
+        )
 
     @classmethod
     def start_containers(cls, bootstrap_container):

--- a/wazo_test_helpers/asset_launching_test_case.py
+++ b/wazo_test_helpers/asset_launching_test_case.py
@@ -12,7 +12,7 @@ import unittest
 import docker as docker_client
 
 logger = logging.getLogger(__name__)
-logging.basicConfig(level=logging.DEBUG)
+logger.setLevel(logging.DEBUG)
 
 
 if os.environ.get('TEST_LOGS') != 'verbose':


### PR DESCRIPTION
## use --ignore-pull-failures flag on pull

why: docker-compose v2 will fail if image is not on docker hub

## use setLevel instead of basicConfig for logger

why: because according the documentation
basicConfig: This function does nothing if the root logger already has
handlers configured for it.

Some module already have logger configured before calling this
library