### PR TITLE
WAZO-2660 Ability to add downstream exchange to bus helper

### DIFF
--- a/wazo_test_helpers/bus.py
+++ b/wazo_test_helpers/bus.py
@@ -51,6 +51,16 @@ class BusClient:
             channel = connection.default_channel
             queue.bind(channel).declare()
 
+    def downstream_exchange_declare(self, name, type_, upstream=None):
+        if not upstream:
+            upstream = self._default_exchange
+        with Connection(self._url) as connection:
+            channel = connection.default_channel
+            exchange = Exchange(name, type_).bind(channel)
+            exchange.declare()
+            upstream.bind(channel).declare()
+            exchange.bind_to(upstream, routing_key='#')
+
 
 class BusMessageAccumulator:
 

--- a/wazo_test_helpers/bus.py
+++ b/wazo_test_helpers/bus.py
@@ -51,6 +51,7 @@ class BusClient:
             channel = connection.default_channel
             queue.bind(channel).declare()
 
+    # FIXME: Remove after routing_key -> headers migration
     def downstream_exchange_declare(self, name, type_, upstream=None):
         if not upstream:
             upstream = self._default_exchange


### PR DESCRIPTION
Why:

* With some consumers listening on wazo-headers,
integration test fails because that exchange does not
exist in test environments.

This change addresses the need by:

* Helps transitioning to using a headers-base exchange
instead of routing keys