### PR TITLE
WAZO-2496 BusAccumulator now captures event's headers

### DIFF
--- a/wazo_test_helpers/bus.py
+++ b/wazo_test_helpers/bus.py
@@ -3,13 +3,7 @@
 
 import uuid
 
-from kombu import (
-    Connection,
-    Consumer,
-    Exchange,
-    Producer,
-    Queue,
-)
+from kombu import Connection, Consumer, Exchange, Producer, Queue
 from kombu.exceptions import OperationalError, TimeoutError
 
 
@@ -65,16 +59,24 @@ class BusMessageAccumulator:
         self._queue = queue
         self._events = []
 
-    def accumulate(self):
+    def accumulate(self, with_headers=False):
         self._pull_events()
-        return self._events
+        if with_headers:
+            return [
+                {'message': message, 'headers': headers}
+                for message, headers in self._events
+            ]
+        return [message for message, _ in self._events]
 
-    def pop(self):
+    def pop(self, with_headers=False):
         self._pull_events()
-        return self._events.pop(0)
+        message, headers = self._events.pop(0)
+        if with_headers:
+            return {'message': message, 'headers': headers}
+        return message
 
-    def push_back(self, event):
-        self._events.insert(0, event)
+    def push_back(self, event, headers=None):
+        self._events.insert(0, (event, headers))
 
     def reset(self):
         self._pull_events()
@@ -91,5 +93,5 @@ class BusMessageAccumulator:
 
     def _on_event(self, body, message):
         # events are already decoded, thanks to the content-type
-        self._events.append(body)
+        self._events.append((body, message.headers))
         message.ack()


### PR DESCRIPTION
Why:

* With the transition to a header base routing, there is a need to be able to easily inspect headers of received messages