### PR TITLE
Pull request for until-return-raise-errors

### DIFF
--- a/wazo_test_helpers/until.py
+++ b/wazo_test_helpers/until.py
@@ -62,9 +62,10 @@ def assert_(assert_function, *args, **kwargs):
         except AssertionError as e:
             errors.append(str(e))
     else:
+        error_message = '\n'.join(errors)
         if message:
-            raise AssertionError(message)
-        raise AssertionError('\n'.join(errors))
+            error_message = message + '\n' + error_message
+        raise AssertionError(error_message)
 
 
 def true(function, *args, **kwargs):

--- a/wazo_test_helpers/until.py
+++ b/wazo_test_helpers/until.py
@@ -157,11 +157,15 @@ def return_(function, *args, **kwargs):
     timeout = kwargs.pop('timeout')
     interval = kwargs.pop('interval', 1)
     message = kwargs.pop('message', None)
+    errors = []
 
     for _ in timeout_executions(timeout, interval):
         try:
             return function(*args, **kwargs)
-        except Exception:
-            logger.debug('Exception caught while waiting for %s to return', function, exc_info=True)
+        except Exception as e:
+            errors.append(str(e))
     else:
-        raise NoMoreTries(message)
+        error_message = '\n'.join(errors)
+        if message:
+            error_message = message + '\n' + error_message
+        raise NoMoreTries(error_message)


### PR DESCRIPTION
## until.return: aggregate errors in the final exception

Why:

* The error is more visible in the exception message than in debug
logger.

## until.assert_: homogenize error message with until.return