### PR TITLE
Clean the Dockerfile for the flask image

### DIFF
--- a/contribs/docker/flask/Dockerfile
+++ b/contribs/docker/flask/Dockerfile
@@ -1,5 +1,3 @@
 FROM python:slim-buster
 
-RUN apt-get update -y && apt-get dist-upgrade -y
-
 RUN python3 -m pip install flask


### PR DESCRIPTION
apt update/upgrade is not needed, as the base image
is not locked to a specific version of Python.