### PR TITLE
asset launching test case: separate assets in docker-compose

### DIFF
--- a/wazo_test_helpers/asset_launching_test_case.py
+++ b/wazo_test_helpers/asset_launching_test_case.py
@@ -305,7 +305,7 @@ class AssetLaunchingTestCase(unittest.TestCase):
     def _docker_compose_options(cls):
         options = [
             '--ansi', 'never',
-            '--project-name', cls.service,
+            '--project-name', cls.service + '_' + cls.asset,
             '--file', os.path.join(cls.assets_root, 'docker-compose.yml'),
             '--file', os.path.join(
                 cls.assets_root, 'docker-compose.{}.override.yml'.format(cls.asset)


### PR DESCRIPTION
Why:

* Allows running different assets in the same time.
* It's useful when using pytest fixtures that are only teardown after
all the tests have finished running

This is a re-revert of 98e922ea80ea84295663a19ba7529a1a305279f2
Since jenkins IPv4 pool has been increased