### PR TITLE
Fix 500 when deleting non-existing user

### DIFF
--- a/contribs/docker/wazo-auth-mock/wazo-auth-mock.py
+++ b/contribs/docker/wazo-auth-mock/wazo-auth-mock.py
@@ -523,7 +523,10 @@ def tenant_get(tenant_uuid):
 
 @app.route(url_prefix + "/0.1/users/<user_uuid>", methods=['DELETE'])
 def users_delete(user_uuid):
-    del users[user_uuid]
+    try:
+        del users[user_uuid]
+    except KeyError:
+        return '', 404
     return '', 204
 
 


### PR DESCRIPTION
Fix 500 error when trying to delete a user who does not exist:

```
INFO:werkzeug:172.26.0.3 - - [30/Nov/2022 14:22:05] "DELETE /0.1/users/xxxxxxxxxxxxxxxxxxxxx HTTP/1.1" 500 -
Traceback (most recent call last):
  File "/usr/local/lib/python2.7/dist-packages/flask/app.py", line 2309, in __call__
    return self.wsgi_app(environ, start_response)
  File "/usr/local/lib/python2.7/dist-packages/flask/app.py", line 2295, in wsgi_app
    response = self.handle_exception(e)
  File "/usr/local/lib/python2.7/dist-packages/flask/app.py", line 1741, in handle_exception
    reraise(exc_type, exc_value, tb)
  File "/usr/local/lib/python2.7/dist-packages/flask/app.py", line 2292, in wsgi_app
    response = self.full_dispatch_request()
  File "/usr/local/lib/python2.7/dist-packages/flask/app.py", line 1815, in full_dispatch_request
    rv = self.handle_user_exception(e)
  File "/usr/local/lib/python2.7/dist-packages/flask/app.py", line 1718, in handle_user_exception
    reraise(exc_type, exc_value, tb)
  File "/usr/local/lib/python2.7/dist-packages/flask/app.py", line 1813, in full_dispatch_request
    rv = self.dispatch_request()
  File "/usr/local/lib/python2.7/dist-packages/flask/app.py", line 1799, in dispatch_request
    return self.view_functions[rule.endpoint](**req.view_args)
  File "/usr/local/bin/wazo-auth-mock.py", line 526, in users_delete
    del users[user_uuid]
KeyError: u'xxxxxxxxxxxxxxxxxxxxxxxx
```