### PR TITLE
WAZO-2943: add `external users` command to mock and client

### DIFF
--- a/contribs/docker/wazo-auth-mock/wazo-auth-mock.py
+++ b/contribs/docker/wazo-auth-mock/wazo-auth-mock.py
@@ -84,6 +84,7 @@ valid_tokens = {
 valid_credentials = {}
 external = {}
 external_config = {}
+external_users = {}
 invalid_username_passwords = [('test', 'foobar')]
 sessions = {}
 refresh_tokens = {}
@@ -162,6 +163,26 @@ def external_auth_external_service_get(user_uuid, external_service):
         return jsonify(external)
     else:
         return '', 404
+
+
+@app.route(url_prefix + "/_reset_external_users", methods=['POST'])
+def external_users_reset():
+    global external_users
+    external_users = {}
+    return '', 204
+
+
+@app.route(url_prefix + "/_set_external_users", methods=['POST'])
+def external_users_set():
+    global external_users
+    external_users = request.get_json()
+    return '', 201
+
+
+@app.route(url_prefix + "/0.1/external/<external_service>/users", methods=['GET'])
+def external_auth_external_service_users(external_service):
+    users = external_users.get(external_service, [])
+    return jsonify({'total': len(users), 'filtered': len(users), 'items': users})
 
 
 @app.route(url_prefix + "/_reset_external_auth", methods=['POST'])

--- a/wazo_test_helpers/auth.py
+++ b/wazo_test_helpers/auth.py
@@ -1,4 +1,4 @@
-# Copyright 2017-2021 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2017-2022 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import logging
@@ -46,6 +46,14 @@ class AuthClient:
     def set_external_auth(self, auth_info):
         url = self.url('_set_external_auth')
         requests.post(url, json=auth_info)
+
+    def reset_external_users(self):
+        url = self.url('_reset_external_users')
+        requests.post(url)
+
+    def set_external_users(self, users_info):
+        url =self.url('_set_external_users')
+        requests.post(url, json=users_info)
 
     def set_tenants(self, *tenants):
         url = self.url('_set_tenants')


### PR DESCRIPTION
Why:

* Needed by the teams plugin to fetch list of connected users with external service