### PR TITLE
tests: pin requests version to avoid breaking docker lib

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,6 +19,9 @@ setup(
     url='http://wazo.community',
 
     packages=find_packages(),
-    install_requires=['docker'],
+    install_requires=[
+        'docker',
+        'requests<2.30',  # Avoid to break docker library
+    ],
     download_url=f'https://github.com/wazo-platform/wazo-test-helpers/tarball/{VERSION}',
 )


### PR DESCRIPTION
why: new requests version (2.30) which include urllib3 v2, include
breaking change that impact docker library