### PR TITLE
Use /usr/bin/env python3 and not local

### DIFF
--- a/contribs/docker/wazo-sysconfd-mock/wazo-sysconfd-mock.py
+++ b/contribs/docker/wazo-sysconfd-mock/wazo-sysconfd-mock.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 # Copyright 2018-2023 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 from __future__ import annotations


### PR DESCRIPTION
reason: This is universal and debian and python images have different locations