### PR TITLE
Pull request for WAZO-3225-dynamic-token-check

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,12 @@
+# See https://pre-commit.com for more information
+repos:
+  - repo: https://github.com/PyCQA/flake8
+    rev: 6.0.0
+    hooks:
+      - id: flake8
+        # Required to make flake8 read from pyproject.toml for now :(
+        additional_dependencies: ["flake8-pyproject"]
+  - repo: https://github.com/psf/black
+    rev: 23.3.0
+    hooks:
+      - id: black

--- a/contribs/docker/wazo-amid-mock/mock-wazo-amid.py
+++ b/contribs/docker/wazo-amid-mock/mock-wazo-amid.py
@@ -16,7 +16,13 @@ logging.basicConfig(level=logging.DEBUG)
 app = Flask(__name__)
 logger = logging.getLogger('amid-mock')
 
-EMPTY_RESPONSES = {'action': {'DeviceStateList': [], 'CoreShowChannels': [], 'Command': {'response': ['Success']}}}
+EMPTY_RESPONSES = {
+    'action': {
+        'DeviceStateList': [],
+        'CoreShowChannels': [],
+        'Command': {'response': ['Success']},
+    }
+}
 
 _requests = deque(maxlen=1024)
 _responses: dict[str, dict] = dict(EMPTY_RESPONSES)
@@ -39,27 +45,35 @@ def handle_generic(e: Exception) -> Response:
 def log_request() -> None:
     if not request.path.startswith('/_'):
         path = request.path
-        log = {'method': request.method,
-               'path': path,
-               'query': dict(request.args.items(multi=True)),
-               'body': request.data.decode('utf-8'),
-               'json': request.json if request.is_json else None,
-               'headers': dict(request.headers)}
+        log = {
+            'method': request.method,
+            'path': path,
+            'query': dict(request.args.items(multi=True)),
+            'body': request.data.decode('utf-8'),
+            'json': request.json if request.is_json else None,
+            'headers': dict(request.headers),
+        }
         _requests.append(log)
 
 
 @app.after_request
 def print_request_response(response: Response) -> Response:
-    logger.debug('request: %s', {
-        'method': request.method,
-        'path': request.path,
-        'query': dict(request.args.items(multi=True)),
-        'body': request.data.decode('utf-8'),
-        'headers': dict(request.headers)
-    })
-    logger.debug('response: %s', {
-        'body': response.data.decode('utf-8'),
-    })
+    logger.debug(
+        'request: %s',
+        {
+            'method': request.method,
+            'path': request.path,
+            'query': dict(request.args.items(multi=True)),
+            'body': request.data.decode('utf-8'),
+            'headers': dict(request.headers),
+        },
+    )
+    logger.debug(
+        'response: %s',
+        {
+            'body': response.data.decode('utf-8'),
+        },
+    )
     return response
 
 

--- a/contribs/docker/wazo-auth-mock/wazo-auth-mock.py
+++ b/contribs/docker/wazo-auth-mock/wazo-auth-mock.py
@@ -32,7 +32,7 @@ DEFAULT_POLICIES = {
     'wazo_default_admin_policy': {
         'uuid': '5650b7e8-6de8-4f5f-994c-000000000002',
         'name': 'wazo_default_admin_policy',
-    }
+    },
 }
 
 valid_tokens = {
@@ -43,7 +43,7 @@ valid_tokens = {
             'uuid': 'uuid',
             'pbx_user_uuid': 'uuid',
             'tenant_uuid': 'ffffffff-ffff-ffff-ffff-ffffffffffff',
-        }
+        },
     },
     'valid-token-multitenant': {
         'auth_id': 'uuid-multitenant',
@@ -52,7 +52,7 @@ valid_tokens = {
             'uuid': 'uuid-multitenant',
             'pbx_user_uuid': 'uuid-multitenant',
             'tenant_uuid': 'eeeeeeee-eeee-eeee-eeee-eeeeeeeeeee1',
-        }
+        },
     },
     'valid-token-master-tenant': {
         'auth_id': 'uuid-tenant-master',
@@ -61,7 +61,7 @@ valid_tokens = {
             'uuid': 'uuid-tenant-master',
             'pbx_user_uuid': 'uuid-tenant-master',
             'tenant_uuid': 'eeeeeeee-eeee-eeee-eeee-eeeeeeeeee10',
-        }
+        },
     },
     'valid-token-sub-tenant': {
         'auth_id': 'uuid-subtenant',
@@ -70,7 +70,7 @@ valid_tokens = {
             'uuid': 'uuid-subtenant',
             'pbx_user_uuid': 'uuid-subtenant',
             'tenant_uuid': 'eeeeeeee-eeee-eeee-eeee-eeeeeeeeee11',
-        }
+        },
     },
     'non-user-token': {
         'auth_id': 'uuid-non-user',
@@ -79,8 +79,8 @@ valid_tokens = {
             'uuid': None,
             'pbx_user_uuid': None,
             'tenant_uuid': 'dddddddd-dddd-dddd-dddd-dddddddddd11',
-        }
-    }
+        },
+    },
 }
 
 valid_credentials = {}
@@ -96,7 +96,6 @@ tenants = [
         'name': 'valid-tenant',
         'parent_uuid': 'ffffffff-ffff-ffff-ffff-ffffffffffff',
     },
-
     {
         'uuid': 'eeeeeeee-eeee-eeee-eeee-eeeeeeeeeee1',
         'name': 'valid-tenant1',
@@ -112,7 +111,6 @@ tenants = [
         'name': 'valid-tenant3',
         'parent_uuid': 'eeeeeeee-eeee-eeee-eeee-eeeeeeeeeee1',
     },
-
     {
         'uuid': 'eeeeeeee-eeee-eeee-eeee-eeeeeeeeee10',
         'name': 'master-tenant',
@@ -158,8 +156,12 @@ def external_config_set() -> tuple[str, int]:
     return '', 201
 
 
-@app.route(f"{url_prefix}/0.1/users/<user_uuid>/external/<external_service>", methods=['GET'])
-def external_auth_external_service_get(user_uuid, external_service) -> Response | tuple[str, int]:
+@app.route(
+    f"{url_prefix}/0.1/users/<user_uuid>/external/<external_service>", methods=['GET']
+)
+def external_auth_external_service_get(
+    user_uuid, external_service
+) -> Response | tuple[str, int]:
     if external:
         return jsonify(external)
     return '', 404
@@ -209,27 +211,35 @@ def handle_generic(e: Exception) -> Response:
 def log_request() -> None:
     if not request.path.startswith('/_'):
         path = request.path
-        log = {'method': request.method,
-               'path': path,
-               'query': dict(request.args.items(multi=True)),
-               'body': request.data.decode('utf-8'),
-               'json': request.json if request.is_json else None,
-               'headers': dict(request.headers)}
+        log = {
+            'method': request.method,
+            'path': path,
+            'query': dict(request.args.items(multi=True)),
+            'body': request.data.decode('utf-8'),
+            'json': request.json if request.is_json else None,
+            'headers': dict(request.headers),
+        }
         _requests.append(log)
 
 
 @app.after_request
 def print_request_response(response: Response) -> Response:
-    logger.debug('request: %s', {
-        'method': request.method,
-        'path': request.path,
-        'query': dict(request.args.items(multi=True)),
-        'body': request.data.decode('utf-8'),
-        'headers': dict(request.headers)
-    })
-    logger.debug('response: %s', {
-        'body': response.data.decode('utf-8'),
-    })
+    logger.debug(
+        'request: %s',
+        {
+            'method': request.method,
+            'path': request.path,
+            'query': dict(request.args.items(multi=True)),
+            'body': request.data.decode('utf-8'),
+            'headers': dict(request.headers),
+        },
+    )
+    logger.debug(
+        'response: %s',
+        {
+            'body': response.data.decode('utf-8'),
+        },
+    )
     return response
 
 
@@ -291,8 +301,9 @@ def remove_token(token_id: str) -> tuple[str, int]:
 @app.route(f"{url_prefix}/_add_invalid_credentials", methods=['POST'])
 def add_invalid_credentials() -> tuple[str, int]:
     request_body = request.get_json()
-    invalid_username_passwords.append((request_body['username'],
-                                       request_body['password']))
+    invalid_username_passwords.append(
+        (request_body['username'], request_body['password'])
+    )
 
     return '', 204
 
@@ -300,8 +311,9 @@ def add_invalid_credentials() -> tuple[str, int]:
 @app.route(f"{url_prefix}/_add_credentials_for_invalid_token", methods=['POST'])
 def add_credentials_for_invalid_token() -> tuple[str, int]:
     request_body = request.get_json()
-    token_that_will_be_invalid_when_used.append((request_body['username'],
-                                                 request_body['password']))
+    token_that_will_be_invalid_when_used.append(
+        (request_body['username'], request_body['password'])
+    )
 
     return '', 204
 
@@ -324,7 +336,9 @@ def token_head_ok(token: str) -> tuple[str, int]:
     if required_tenant_uuid:
         token_tenant_uuid = valid_tokens[token]['metadata']['tenant_uuid']
         token_tenant = _find_tenant(token_tenant_uuid)
-        visible_tenant_uuids = [tenant['uuid'] for tenant in _find_tenant_children(token_tenant)] + [token_tenant['uuid']]
+        visible_tenant_uuids = [
+            tenant['uuid'] for tenant in _find_tenant_children(token_tenant)
+        ] + [token_tenant['uuid']]
         logger.debug('Visible tenants: %s', visible_tenant_uuids)
         if required_tenant_uuid not in visible_tenant_uuids:
             return '', 403
@@ -353,9 +367,7 @@ def token_get(token: str) -> Response | tuple[str, int]:
     result = dict(valid_tokens[token])
     result['metadata'].setdefault('pbx_user_uuid', result['metadata']['uuid'])
     result.setdefault('auth_id', result['metadata']['uuid'])
-    return jsonify({
-        'data': result
-    })
+    return jsonify({'data': result})
 
 
 def _valid_acl(token_id: str) -> bool:
@@ -436,7 +448,7 @@ def users_post() -> Response:
         'username': args.get('username', None),
         'emails': [email] if email else [],
         'enabled': args.get('enabled', True),
-        'tenant_uuid': request.headers.get('Wazo-Tenant', None)
+        'tenant_uuid': request.headers.get('Wazo-Tenant', None),
     }
     users[user['uuid']] = user
     return jsonify(user)
@@ -580,14 +592,21 @@ def policies_get() -> tuple[Response, int]:
     name = request.args.get('name')
     policies = [policies_dict.get(name)] if name else policies_dict.items()
 
-    return jsonify({
-        'items': policies,
-        'total': len(policies),
-        'filtered': len(policies),
-    }), 200
+    return (
+        jsonify(
+            {
+                'items': policies,
+                'total': len(policies),
+                'filtered': len(policies),
+            }
+        ),
+        200,
+    )
 
 
-@app.route(f"{url_prefix}/0.1/users/<user_uuid>/policies/<policy_uuid>", methods=['PUT'])
+@app.route(
+    f"{url_prefix}/0.1/users/<user_uuid>/policies/<policy_uuid>", methods=['PUT']
+)
 def users_policies_put(user_uuid: str, policy_uuid: str) -> tuple[str, int]:
     return '', 204
 

--- a/contribs/docker/wazo-confd-mock/mock-wazo-confd.py
+++ b/contribs/docker/wazo-confd-mock/mock-wazo-confd.py
@@ -61,27 +61,35 @@ def handle_generic(e: Exception) -> Response:
 def log_request() -> None:
     if not request.path.startswith('/_'):
         path = request.path
-        log = {'method': request.method,
-               'path': path,
-               'query': dict(request.args.items(multi=True)),
-               'body': request.data.decode('utf-8'),
-               'json': request.json if request.is_json else None,
-               'headers': dict(request.headers)}
+        log = {
+            'method': request.method,
+            'path': path,
+            'query': dict(request.args.items(multi=True)),
+            'body': request.data.decode('utf-8'),
+            'json': request.json if request.is_json else None,
+            'headers': dict(request.headers),
+        }
         _requests.append(log)
 
 
 @app.after_request
 def print_request_response(response: Response) -> Response:
-    logger.debug('request: %s', {
-        'method': request.method,
-        'path': request.path,
-        'query': dict(request.args.items(multi=True)),
-        'body': request.data.decode('utf-8'),
-        'headers': dict(request.headers)
-    })
-    logger.debug('response: %s', {
-        'body': response.data.decode('utf-8'),
-    })
+    logger.debug(
+        'request: %s',
+        {
+            'method': request.method,
+            'path': request.path,
+            'query': dict(request.args.items(multi=True)),
+            'body': request.data.decode('utf-8'),
+            'headers': dict(request.headers),
+        },
+    )
+    logger.debug(
+        'response: %s',
+        {
+            'body': response.data.decode('utf-8'),
+        },
+    )
     return response
 
 
@@ -132,7 +140,11 @@ def application(application_uuid: str) -> Response | tuple[str, int]:
 def conferences() -> Response:
     conferences = list(_responses['conferences'].values())
     if 'name' in request.args:
-        conferences = [conference for conference in conferences if conference['name'] == request.args['name']]
+        conferences = [
+            conference
+            for conference in conferences
+            if conference['name'] == request.args['name']
+        ]
     return jsonify({'items': conferences})
 
 
@@ -191,7 +203,9 @@ def context(context_id: str) -> Response | tuple[str, int]:
 def meetings() -> Response:
     meetings = list(_responses['meetings'].values())
     if 'name' in request.args:
-        meetings = [meeting for meeting in meetings if meeting['name'] == request.args['name']]
+        meetings = [
+            meeting for meeting in meetings if meeting['name'] == request.args['name']
+        ]
     return jsonify({'items': meetings})
 
 
@@ -231,16 +245,12 @@ def lines_of_user(user_uuid: str) -> Response | tuple[str, int]:
     if user_uuid not in _responses['users']:
         return '', 404
 
-    return jsonify({
-        'items': _responses['user_lines'].get(user_uuid, [])
-    })
+    return jsonify({'items': _responses['user_lines'].get(user_uuid, [])})
 
 
 @app.route('/1.1/users/<user_uuid>/voicemails')
 def voicemails_of_user(user_uuid: str) -> Response:
-    return jsonify({
-        'items': _responses['user_voicemails'].get(user_uuid, [])
-    })
+    return jsonify({'items': _responses['user_voicemails'].get(user_uuid, [])})
 
 
 @app.route('/1.1/trunks')

--- a/contribs/docker/wazo-sysconfd-mock/wazo-sysconfd-mock.py
+++ b/contribs/docker/wazo-sysconfd-mock/wazo-sysconfd-mock.py
@@ -26,12 +26,14 @@ def handle_generic(e: Exception) -> Response:
 def log_request() -> None:
     if not request.path.startswith('/_requests'):
         path = request.path
-        log = {'method': request.method,
-               'path': path,
-               'query': dict(request.args.items(multi=True)),
-               'body': request.data.decode('utf-8'),
-               'json': request.json if request.is_json else None,
-               'headers': dict(request.headers)}
+        log = {
+            'method': request.method,
+            'path': path,
+            'query': dict(request.args.items(multi=True)),
+            'body': request.data.decode('utf-8'),
+            'json': request.json if request.is_json else None,
+            'headers': dict(request.headers),
+        }
         _requests.append(log)
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,15 @@
+[tool.black]
+skip-string-normalization = true
+
+[tool.flake8]
+show-source = true
+max-line-length = 99
+application-import-names = "wazo_test_helpers"
+ignore = [
+  "E203", # whitespace before ':'
+  "W503", # line break before binary operator
+]
+exclude = [
+    ".tox",
+    ".eggs",
+]

--- a/setup.py
+++ b/setup.py
@@ -10,14 +10,10 @@ VERSION = '1.0.0'
 setup(
     name='wazo-test-helpers',
     version=VERSION,
-
     description='Wazo test helpers',
-
     author='Wazo Authors',
     author_email='dev@wazo.community',
-
     url='http://wazo.community',
-
     packages=find_packages(),
     install_requires=[
         'docker',

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,14 @@
+# Tox (http://tox.testrun.org/) is a tool for running tests
+# in multiple virtualenvs. This configuration file will run the
+# test suite on all supported python versions. To use it, "pip install tox"
+# and then run "tox" from this directory.
+
+[tox]
+envlist = linters
+skipsdist = false
+
+[testenv:linters]
+basepython = python3.10
+skip_install = true
+deps = pre-commit
+commands = pre-commit run --all-files

--- a/wazo_test_helpers/asset_launching_test_case.py
+++ b/wazo_test_helpers/asset_launching_test_case.py
@@ -48,7 +48,10 @@ class NoSuchPort(Exception):
 
 class ContainerStartFailed(Exception):
     def __init__(self, stdout, stderr, return_code):
-        message = f'Container start failed (code {return_code}): output follows.\nstdout:\n{stdout}\nstderr:\n{stderr}'
+        message = (
+            f'Container start failed (code {return_code}): '
+            f'output follows.\nstdout:\n{stdout}\nstderr:\n{stderr}'
+        )
         super().__init__(message)
 
         self.stdout = stdout

--- a/wazo_test_helpers/asset_launching_test_case.py
+++ b/wazo_test_helpers/asset_launching_test_case.py
@@ -112,21 +112,27 @@ class AssetLaunchingTestCase(unittest.TestCase):
 
     @classmethod
     def rm_containers(cls):
-        _run_cmd(['docker-compose'] + cls._docker_compose_options() +
-                 ['down', '--timeout', '0', '--volumes'])
+        _run_cmd(
+            ['docker-compose']
+            + cls._docker_compose_options()
+            + ['down', '--timeout', '0', '--volumes']
+        )
 
     @classmethod
     def pull_containers(cls):
         _run_cmd(
-            ['docker-compose'] +
-            cls._docker_compose_options() +
-            ['pull', '--ignore-pull-failures']
+            ['docker-compose']
+            + cls._docker_compose_options()
+            + ['pull', '--ignore-pull-failures']
         )
 
     @classmethod
     def start_containers(cls, bootstrap_container):
-        completed_process = _run_cmd(['docker-compose'] + cls._docker_compose_options() +
-                                     ['run', '--rm', bootstrap_container])
+        completed_process = _run_cmd(
+            ['docker-compose']
+            + cls._docker_compose_options()
+            + ['run', '--rm', bootstrap_container]
+        )
         if completed_process.returncode != 0:
             stdout = completed_process.stdout
             stderr = completed_process.stderr
@@ -138,19 +144,19 @@ class AssetLaunchingTestCase(unittest.TestCase):
 
     @classmethod
     def kill_containers(cls):
-        _run_cmd(['docker-compose'] + cls._docker_compose_options() +
-                 ['kill'])
+        _run_cmd(['docker-compose'] + cls._docker_compose_options() + ['kill'])
 
     @classmethod
     def log_containers(cls):
-        return _run_cmd(['docker-compose'] + cls._docker_compose_options() +
-                        ['logs', '--no-color']).stdout
+        return _run_cmd(
+            ['docker-compose'] + cls._docker_compose_options() + ['logs', '--no-color']
+        ).stdout
 
     @classmethod
     def log_containers_to_file(cls, log_file):
         return subprocess.run(
-            ['docker-compose'] + cls._docker_compose_options() +
-            ['logs', '--no-color'], stdout=log_file
+            ['docker-compose'] + cls._docker_compose_options() + ['logs', '--no-color'],
+            stdout=log_file,
         )
 
     @classmethod
@@ -276,7 +282,9 @@ class AssetLaunchingTestCase(unittest.TestCase):
         return _run_cmd(docker_command)
 
     @classmethod
-    def docker_copy_across_containers(cls, src_service_name, src, dst_service_name, dst):
+    def docker_copy_across_containers(
+        cls, src_service_name, src, dst_service_name, dst
+    ):
         container_src = f'{cls._container_id(src_service_name)}:{src}'
         container_dst = f'{cls._container_id(dst_service_name)}:{dst}'
         with tempfile.TemporaryDirectory() as tmp_dirname:
@@ -292,11 +300,17 @@ class AssetLaunchingTestCase(unittest.TestCase):
 
     @classmethod
     def _container_id(cls, service_name):
-        result = _run_cmd(['docker-compose'] + cls._docker_compose_options() +
-                          ['ps', '-aq', service_name], stderr=False).stdout.strip()
+        result = _run_cmd(
+            ['docker-compose']
+            + cls._docker_compose_options()
+            + ['ps', '-aq', service_name],
+            stderr=False,
+        ).stdout.strip()
         result = result.decode('utf-8')
         if '\n' in result:
-            raise AssertionError(f'There is more than one container running with name {service_name}')
+            raise AssertionError(
+                f'There is more than one container running with name {service_name}'
+            )
         if not result:
             raise NoSuchService(service_name)
         return result
@@ -304,12 +318,14 @@ class AssetLaunchingTestCase(unittest.TestCase):
     @classmethod
     def _docker_compose_options(cls):
         options = [
-            '--ansi', 'never',
-            '--project-name', cls.service + '_' + cls.asset,
-            '--file', os.path.join(cls.assets_root, 'docker-compose.yml'),
-            '--file', os.path.join(
-                cls.assets_root, f'docker-compose.{cls.asset}.override.yml'
-            ),
+            '--ansi',
+            'never',
+            '--project-name',
+            cls.service + '_' + cls.asset,
+            '--file',
+            os.path.join(cls.assets_root, 'docker-compose.yml'),
+            '--file',
+            os.path.join(cls.assets_root, f'docker-compose.{cls.asset}.override.yml'),
         ]
         extra = os.getenv("WAZO_TEST_DOCKER_OVERRIDE_EXTRA")
         if extra:
@@ -320,9 +336,9 @@ class AssetLaunchingTestCase(unittest.TestCase):
     def _maybe_dump_docker_logs(cls):
         if os.getenv('WAZO_TEST_DOCKER_LOGS_ENABLED', '0') == '1':
             filename_prefix = f'{cls.__module__}.{cls.__name__}-'
-            with tempfile.NamedTemporaryFile(dir=cls.get_log_directory(),
-                                             prefix=filename_prefix,
-                                             delete=False) as logfile:
+            with tempfile.NamedTemporaryFile(
+                dir=cls.get_log_directory(), prefix=filename_prefix, delete=False
+            ) as logfile:
                 cls.log_containers_to_file(logfile)
             logger.debug('Container logs dumped to %s', logfile.name)
 
@@ -333,7 +349,9 @@ class AssetLaunchingTestCase(unittest.TestCase):
             default_logging_dir = '/tmp/wazo-integration-{}'.format(
                 ''.join(random.choice(char_set) for _ in range(8))
             )
-            AssetLaunchingTestCase.log_dir = os.getenv('WAZO_TEST_DOCKER_LOGS_DIR', default_logging_dir)
+            AssetLaunchingTestCase.log_dir = os.getenv(
+                'WAZO_TEST_DOCKER_LOGS_DIR', default_logging_dir
+            )
             if not os.path.exists(AssetLaunchingTestCase.log_dir):
                 os.makedirs(AssetLaunchingTestCase.log_dir, mode=0o755)
         return AssetLaunchingTestCase.log_dir

--- a/wazo_test_helpers/auth.py
+++ b/wazo_test_helpers/auth.py
@@ -1,4 +1,4 @@
-# Copyright 2017-2022 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2017-2023 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import logging
@@ -98,7 +98,16 @@ class MockUserToken:
         kwargs.setdefault('user_uuid', str(uuid.uuid4()))
         return cls(**kwargs)
 
-    def __init__(self, token, user_uuid, wazo_uuid=None, metadata=None, acl=None, session_uuid=None):
+    def __init__(
+        self,
+        token,
+        user_uuid,
+        wazo_uuid=None,
+        metadata=None,
+        acl=None,
+        session_uuid=None,
+        utc_expires_at=None,
+    ):
         self.token_id = token
         self.auth_id = user_uuid
         self.wazo_uuid = wazo_uuid or str(uuid.uuid4())
@@ -106,6 +115,7 @@ class MockUserToken:
         self.session_uuid = session_uuid
         self.metadata = metadata or {}
         self.metadata.setdefault('uuid', user_uuid)
+        self.utc_expires_at = utc_expires_at
 
     def to_dict(self):
         result = {
@@ -114,6 +124,7 @@ class MockUserToken:
             'xivo_uuid': self.wazo_uuid,
             'session_uuid': self.session_uuid,
             'metadata': self.metadata,
+            'utc_expires_at': self.utc_expires_at,
         }
         if self.acl is not None:
             result['acl'] = self.acl

--- a/wazo_test_helpers/auth.py
+++ b/wazo_test_helpers/auth.py
@@ -10,16 +10,13 @@ logger = logging.getLogger(__name__)
 
 
 class AuthClient:
-
     def __init__(self, host, port):
         self.host = host
         self.port = port
 
     def url(self, *parts):
         return 'http://{host}:{port}/{path}'.format(
-            host=self.host,
-            port=self.port,
-            path='/'.join(parts)
+            host=self.host, port=self.port, path='/'.join(parts)
         )
 
     def is_up(self):
@@ -52,7 +49,7 @@ class AuthClient:
         requests.post(url)
 
     def set_external_users(self, users_info):
-        url =self.url('_set_external_users')
+        url = self.url('_set_external_users')
         requests.post(url, json=users_info)
 
     def set_tenants(self, *tenants):
@@ -91,7 +88,6 @@ class AuthClient:
 
 
 class MockUserToken:
-
     @classmethod
     def some_token(cls, **kwargs):
         kwargs.setdefault('token', str(uuid.uuid4()))
@@ -132,7 +128,6 @@ class MockUserToken:
 
 
 class MockCredentials:
-
     def __init__(self, username, password):
         self.username = username
         self.password = password

--- a/wazo_test_helpers/bus.py
+++ b/wazo_test_helpers/bus.py
@@ -9,13 +9,20 @@ from wazo_test_helpers import until
 
 
 class BusClient:
-
     def __init__(self, url, exchange):
         self._url = url
         self._default_exchange = exchange
 
     @classmethod
-    def from_connection_fields(cls, user='guest', password='guest', host='localhost', port=5672, exchange_name='xivo', exchange_type='topic'):
+    def from_connection_fields(
+        cls,
+        user='guest',
+        password='guest',
+        host='localhost',
+        port=5672,
+        exchange_name='xivo',
+        exchange_type='topic',
+    ):
         url = f'amqp://{user}:{password}@{host}:{port}//'
         exchange = Exchange(exchange_name, type=exchange_type)
         return cls(url, exchange)
@@ -23,7 +30,9 @@ class BusClient:
     def is_up(self):
         try:
             with Connection(self._url) as connection:
-                producer = Producer(connection, exchange=self._default_exchange, auto_declare=True)
+                producer = Producer(
+                    connection, exchange=self._default_exchange, auto_declare=True
+                )
                 producer.publish('', routing_key='test')
         except (OSError, OperationalError):
             return False
@@ -80,7 +89,6 @@ class BusClient:
 
 
 class BusMessageAccumulator:
-
     def __init__(self, url, queue):
         self._url = url
         self._queue = queue

--- a/wazo_test_helpers/db.py
+++ b/wazo_test_helpers/db.py
@@ -1,4 +1,4 @@
-# Copyright 2018 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2018-2023 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import logging
@@ -10,15 +10,10 @@ logger = logging.getLogger(__name__)
 
 
 class DBUserClient:
-
     @classmethod
     def build(cls, user, password, host, port, db=None):
         tpl = "postgresql://{user}:{password}@{host}:{port}/{db}"
-        uri = tpl.format(user=user,
-                         password=password,
-                         host=host,
-                         port=port,
-                         db=db)
+        uri = tpl.format(user=user, password=password, host=host, port=port, db=db)
         return cls(uri)
 
     def __init__(self, db_uri):

--- a/wazo_test_helpers/filesystem.py
+++ b/wazo_test_helpers/filesystem.py
@@ -1,6 +1,7 @@
 # Copyright 2023 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
+
 class FileSystemClient:
     user = 'root'
     group = 'root'

--- a/wazo_test_helpers/filesystem.py
+++ b/wazo_test_helpers/filesystem.py
@@ -1,0 +1,24 @@
+# Copyright 2023 The Wazo Authors  (see the AUTHORS file)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+class FileSystemClient:
+    user = 'root'
+    group = 'root'
+
+    def __init__(self, execute, service_name=None, root=False):
+        self.execute = execute
+        self.service_name = service_name
+        self.root = root
+
+    def create_file(self, path, content='content', mode='666', root=False):
+        command = ['sh', '-c', f'cat <<EOF > {path}\n{content}\nEOF']
+        self.execute(command, service_name=self.service_name)
+        command = ['chmod', mode, path]
+        self.execute(command, service_name=self.service_name)
+        if not root and not self.root:
+            command = ['chown', f'{self.user}:{self.group}', path]
+            self.execute(command, service_name=self.service_name)
+
+    def remove_file(self, path):
+        command = ['rm', '-f', f'{path}']
+        self.execute(command, service_name=self.service_name)

--- a/wazo_test_helpers/hamcrest/has_callable.py
+++ b/wazo_test_helpers/hamcrest/has_callable.py
@@ -17,7 +17,6 @@ __license__ = "BSD, see License.txt"
 
 
 class IsObjectWithCallable(BaseMatcher):
-
     def __init__(self, callable_name, value_matcher):
         self.callable_name = callable_name
         self.value_matcher = value_matcher
@@ -33,10 +32,9 @@ class IsObjectWithCallable(BaseMatcher):
         return self.value_matcher.matches(value)
 
     def describe_to(self, description):
-        description.append_text("an object with a callable '") \
-                                        .append_text(self.callable_name) \
-                                        .append_text("' matching ") \
-                                        .append_description_of(self.value_matcher)
+        description.append_text("an object with a callable '").append_text(
+            self.callable_name
+        ).append_text("' matching ").append_description_of(self.value_matcher)
 
     def describe_mismatch(self, item, mismatch_description):
         if item is None:
@@ -44,15 +42,14 @@ class IsObjectWithCallable(BaseMatcher):
             return
 
         if not hasattr(item, self.callable_name):
-            mismatch_description.append_description_of(item) \
-                                .append_text(' did not have the ') \
-                                .append_description_of(self.callable_name) \
-                                .append_text(' callable')
+            mismatch_description.append_description_of(item).append_text(
+                ' did not have the '
+            ).append_description_of(self.callable_name).append_text(' callable')
             return
 
-        mismatch_description.append_text('callable ') \
-                            .append_description_of(self.callable_name) \
-                            .append_text(' ')
+        mismatch_description.append_text('callable ').append_description_of(
+            self.callable_name
+        ).append_text(' ')
         value = getattr(item, self.callable_name)()
         self.value_matcher.describe_mismatch(value, mismatch_description)
 

--- a/wazo_test_helpers/hamcrest/has_callable.py
+++ b/wazo_test_helpers/hamcrest/has_callable.py
@@ -4,7 +4,7 @@
 # Copyright 2018 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-# Derived from https://github.com/hamcrest/PyHamcrest/blob/master/src/hamcrest/library/object/hasproperty.py
+# Derived from https://github.com/hamcrest/PyHamcrest/blob/master/src/hamcrest/library/object/hasproperty.py  # noqa
 
 from hamcrest.core.base_matcher import BaseMatcher
 from hamcrest.core import anything

--- a/wazo_test_helpers/hamcrest/raises.py
+++ b/wazo_test_helpers/hamcrest/raises.py
@@ -90,7 +90,10 @@ def raises(exception, matcher=None):
     the actual exception object must match the matcher.
     Examples::
         assert_that(calling(int).with_args('q'), raises(TypeError))
-        assert_that(calling(parse, broken_input), raises(ValueError, has_property('input', 'brokn')))
+        assert_that(
+            calling(parse, broken_input),
+            raises(ValueError, has_property('input', 'brokn')),
+        )
     """
 
     return Raises(exception, matcher)

--- a/wazo_test_helpers/hamcrest/raises.py
+++ b/wazo_test_helpers/hamcrest/raises.py
@@ -67,12 +67,15 @@ class Raises(BaseMatcher):
             description.append_text('No exception raised.')
         elif isinstance(self.actual, self.expected) and self.matcher is not None:
             description.append_text('Exception did not match ')
-            description.append_description_of(self.matcher) \
-                       .append_text(' because ')
+            description.append_description_of(self.matcher).append_text(' because ')
             self.matcher.describe_mismatch(self.actual, description)
         else:
-            description.append_text(f'{type(self.actual)} was raised instead: {str(self.actual)}\n')
-            traceback_lines = traceback.format_exception(type(self.actual), self.actual, self.actual.__traceback__)
+            description.append_text(
+                f'{type(self.actual)} was raised instead: {str(self.actual)}\n'
+            )
+            traceback_lines = traceback.format_exception(
+                type(self.actual), self.actual, self.actual.__traceback__
+            )
             for traceback_line in traceback_lines:
                 description.append_text(traceback_line)
 

--- a/wazo_test_helpers/hamcrest/uuid_.py
+++ b/wazo_test_helpers/hamcrest/uuid_.py
@@ -1,8 +1,10 @@
-# Copyright 2017 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2017-2023 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from functools import partial
 from hamcrest import matches_regexp
 
 
-uuid_ = partial(matches_regexp, '[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}')
+uuid_ = partial(
+    matches_regexp, '[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}'
+)

--- a/wazo_test_helpers/mock.py
+++ b/wazo_test_helpers/mock.py
@@ -1,11 +1,10 @@
-# Copyright 2017-2019 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2017-2023 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import uuid
 
 
 class _UUIDMatcher:
-
     def __eq__(self, other):
         try:
             uuid.UUID(hex=other)

--- a/wazo_test_helpers/wait_strategy.py
+++ b/wazo_test_helpers/wait_strategy.py
@@ -1,14 +1,12 @@
-# Copyright 2016-2019 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2016-2023 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 
 class WaitStrategy:
-
     def wait(self, integration_test):
         raise NotImplementedError()
 
 
 class NoWaitStrategy(WaitStrategy):
-
     def wait(self, integration_test):
         pass

--- a/zuul.yaml
+++ b/zuul.yaml
@@ -1,3 +1,4 @@
 - project:
     templates:
+      - wazo-tox-linters-310
       - docker-build-template


### PR DESCRIPTION
## auth: allow to set utc_expires_at on token

why: used by wazo-websocketd for dynamic auth check strategy

## add FileSystemClient

why: mostly used to dynamically generate configuration on service
note: we use cat instead of echo to write file to allow to have carriage
return

## add tox/pre-commit and linters


## blackify


## fix flake8 issues


## zuul: run linters