### PR TITLE
WP-1612: add recurse to contexts route

### DIFF
--- a/contribs/docker/wazo-confd-mock/mock-wazo-confd.py
+++ b/contribs/docker/wazo-confd-mock/mock-wazo-confd.py
@@ -199,7 +199,10 @@ def moh() -> Response:
 
 @app.route('/1.1/contexts')
 def contexts() -> Response:
-    return jsonify({'items': list(_responses['contexts'].values())})
+    recurse_raw = request.args.get('recurse') or ''
+    recurse = recurse_raw.lower() == 'true'
+    items = list(_responses['contexts'].values()) if recurse else []
+    return jsonify({'items': items})
 
 
 @app.route('/1.1/contexts/<context_id>')

--- a/contribs/docker/wazo-confd-mock/mock-wazo-confd.py
+++ b/contribs/docker/wazo-confd-mock/mock-wazo-confd.py
@@ -192,7 +192,8 @@ def line(line_id: str) -> Response | tuple[str, int]:
 
 @app.route('/1.1/moh')
 def moh() -> Response:
-    recurse = request.args.get('recurse')
+    recurse_raw = request.args.get('recurse') or ''
+    recurse = recurse_raw.lower() == 'true'
     items = list(_responses['moh'].values()) if recurse else []
     return jsonify({'items': items})
 


### PR DESCRIPTION
Also, fix recurse logic for moh route

Why: request.args.get('...') always returns a string, thus  will always
be True.